### PR TITLE
Replace obsolete AC_TRY_COMPILE with AC_COMPILE_IFELSE

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -29,14 +29,14 @@ if test "$PHP_EIO" != "no"; then
         dnl # only for PECL, not for PHP
         export OLD_CPPFLAGS="$CPPFLAGS"
         export CPPFLAGS="$CPPFLAGS $INCLUDES"
-        AC_TRY_COMPILE([#include <php_version.h>], [
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <php_version.h>]], [[
             #if PHP_MAJOR_VERSION > 5
             # error PHP > 5
             #endif
-        ], [
+        ]])],[
             subdir=php5
             AC_MSG_RESULT([PHP 5.x])
-        ], [
+        ],[
             subdir=php7
             AC_MSG_RESULT([PHP 7.x])
         ])


### PR DESCRIPTION
Hello, Autoconf made several macros obsolete including the `AC_TRY_COMPILE` in 2000:
http://git.savannah.gnu.org/cgit/autoconf.git/tree/ChangeLog.2

It should be replaced with the current `AC_COMPILE_IFELSE` instead.

PHP 5.3 required Autoconf 2.13 or newer, since PHP 5.4 the autoconf 2.59 or newer was required, and since PHP 7.2, autoconf 2.64 or newer is required.

It is fairly safe to upgrade and take the recommendation advice of autoconf upgrade manual since the upgrade should be compatible at least with PHP versions 5.4 and up, on some systems even with PHP 5.3.

Reference docs:
- https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Obsolete-Macros.html

Thank you for considering merging this or checking it out. In case of doubts or questions just ask...
