### PR TITLE
Add check for HAVE_STRUCT_STAT_ST_BLKSIZE and HAVE_STRUCT_STAT_ST_RDEV

### DIFF
--- a/php7/php_eio.c
+++ b/php7/php_eio.c
@@ -768,13 +768,13 @@ static int php_eio_res_cb(eio_req *req)
 				add_assoc_long(&zresult, "uid", EIO_STAT_BUF(req)->st_uid);
 				add_assoc_long(&zresult, "size", EIO_STAT_BUF(req)->st_size);
 				add_assoc_long(&zresult, "gid", EIO_STAT_BUF(req)->st_gid);
-#ifdef HAVE_ST_RDEV
+#if defined(HAVE_ST_RDEV) || defined(HAVE_STRUCT_STAT_ST_RDEV)
 				add_assoc_long(&zresult, "rdev", EIO_STAT_BUF(req)->st_rdev);
 #else
 				add_assoc_long(&zresult, "rdev", -1);
 #endif
 
-#ifdef HAVE_ST_BLKSIZE
+#if defined(HAVE_ST_BLKSIZE) || defined(HAVE_STRUCT_STAT_ST_BLKSIZE)
 				add_assoc_long(&zresult, "blksize", EIO_STAT_BUF(req)->st_blksize);
 #else
 				add_assoc_long(&zresult, "blksize", -1);


### PR DESCRIPTION
Hello,

Since PHP 7.3 the Autoconf macros `AC_STRUCT_ST_BLKSIZE` and `AC_STRUCT_ST_RDEV` were replaced with the new `AC_CHECK_MEMBERS`.

Previous macros defined constants `HAVE_ST_BLKIZE` and `HAVE_ST_RDEV`. New macros used in PHP build system now define the `HAVE_STAT_ST_BLKSIZE` and `HAVE_STAT_ST_RDEV` in the system php_config.h file.

This patch provides also compatibility with PHP <= 7.2 versions.

Refs:
- https://github.com/php/php-src/commit/d2184efb7be1b3bfb355e4a6e671ceacc3896eeb

Thanks.