### PR TITLE
Fix deprecated calls on PHP 8.1

### DIFF
--- a/tests/eio_get_last_error.phpt
+++ b/tests/eio_get_last_error.phpt
@@ -4,7 +4,7 @@ Check for eio_get_last_error function
 <?php 
 $temp_filename = "eio-temp-file-nonexistent.tmp";
 
-eio_open($temp_filename, NULL, NULL, EIO_PRI_DEFAULT, 
+eio_open($temp_filename, 0, 0, EIO_PRI_DEFAULT,
 	function ($data, $result, $req) {
 		if ($result < 0) {
 			var_dump(eio_get_last_error($req));

--- a/tests/eio_grp_add.phpt
+++ b/tests/eio_grp_add.phpt
@@ -36,7 +36,7 @@ function my_grp_file_read_callback($data, $result) {
 
 
 $grp = eio_grp("my_grp_done", "my_grp_data");
-$req = eio_open($temp_filename, EIO_O_RDWR | EIO_O_APPEND , NULL, 0, "my_grp_file_opened_callback", NULL);
+$req = eio_open($temp_filename, EIO_O_RDWR | EIO_O_APPEND , 0, 0, "my_grp_file_opened_callback", NULL);
 eio_grp_add($grp, $req);
 
 var_dump($grp);

--- a/tests/eio_stat_error.phpt
+++ b/tests/eio_stat_error.phpt
@@ -31,7 +31,7 @@ function my_open_cb($data, $result) {
 eio_stat($tmp_filename, EIO_PRI_DEFAULT, "my_res_cb", "eio_stat");
 eio_lstat($tmp_filename, EIO_PRI_DEFAULT, "my_res_cb", "eio_lstat");
 eio_event_loop();
-eio_open($tmp_filename, EIO_O_RDONLY, NULL, EIO_PRI_DEFAULT, "my_open_cb", "eio_open");
+eio_open($tmp_filename, EIO_O_RDONLY, 0, EIO_PRI_DEFAULT, "my_open_cb", "eio_open");
 eio_event_loop();
 
 @unlink($tmp_filename);

--- a/tests/eio_write_variation.phpt
+++ b/tests/eio_write_variation.phpt
@@ -8,8 +8,8 @@ $filename = '/tmp/tmp_file' .uniqid();
 touch($filename);
 
 
-eio_open($filename, EIO_O_RDWR, NULL, EIO_PRI_DEFAULT, function($filename, $fd) use ($str) {
-	eio_write($fd, $str, strlen($str), 0, null, function($fd, $written) use ($str, $filename) {
+eio_open($filename, EIO_O_RDWR, 0, EIO_PRI_DEFAULT, function($filename, $fd) use ($str) {
+	eio_write($fd, $str, strlen($str), 0, 0, function($fd, $written) use ($str, $filename) {
 		var_dump([
 			'written'  => $written,
 			'strlen'   => strlen($str),

--- a/tests/fork.phpt
+++ b/tests/fork.phpt
@@ -20,8 +20,8 @@ $pid = pcntl_fork();
 if ($pid == -1) {
 	die('could not fork');
 } else if ($pid) {
-	eio_open($filename, EIO_O_RDWR, NULL, EIO_PRI_DEFAULT, function($filename, $fd) use ($str) {
-		eio_write($fd, $str, strlen($str), 0, null, function($fd, $written) use ($str, $filename) {
+	eio_open($filename, EIO_O_RDWR, 0, EIO_PRI_DEFAULT, function($filename, $fd) use ($str) {
+		eio_write($fd, $str, strlen($str), 0, 0, function($fd, $written) use ($str, $filename) {
 			printf("w: %d l: %d f: %d c: %d\n",
 				$written,
 				strlen($str),
@@ -36,8 +36,8 @@ if ($pid == -1) {
 
 } else {
 	// we are the child
-	eio_open($filename2, EIO_O_RDWR, NULL, EIO_PRI_DEFAULT, function($filename2, $fd) use ($str) {
-		eio_write($fd, $str, strlen($str), 0, null, function($fd, $written) use ($str, $filename2) {
+	eio_open($filename2, EIO_O_RDWR, 0, EIO_PRI_DEFAULT, function($filename2, $fd) use ($str) {
+		eio_write($fd, $str, strlen($str), 0, 0, function($fd, $written) use ($str, $filename2) {
 			printf("w: %d l: %d f: %d c: %d\n",
 				$written,
 				strlen($str),


### PR DESCRIPTION
Without

```
TEST 8/30 [tests/eio_get_last_error.phpt]
========DIFF========
001+ Deprecated: eio_open(): Passing null to parameter #2 ($flags) of type int is deprecated in /work/GIT/pecl-and-ext/eio/tests/eio_get_last_error.php on line 9
002+ 
003+ Deprecated: eio_open(): Passing null to parameter #3 ($mode) of type int is deprecated in /work/GIT/pecl-and-ext/eio/tests/eio_get_last_error.php on line 9
     string(25) "No such file or directory"
========DONE========
FAIL Check for eio_get_last_error function [tests/eio_get_last_error.phpt] 
TEST 9/30 [tests/eio_grp_add.phpt]
========DIFF========
001+ Deprecated: eio_open(): Passing null to parameter #3 ($mode) of type int is deprecated in /work/GIT/pecl-and-ext/eio/tests/eio_grp_add.php on line 36
     resource(%d) of type (EIO Group Descriptor)
     bool(true)
     string(%d) "%s"
--
========DONE========
FAIL Check for eio_grp_add function basic behaviour [tests/eio_grp_add.phpt] 
TEST 24/30 [tests/eio_stat_error.phpt]
========DIFF========
     string(%d) "eio_%stat"
     int(%d)
     string(%d) "eio_%stat"
005+ 
006+ Deprecated: eio_open(): Passing null to parameter #3 ($mode) of type int is deprecated in /work/GIT/pecl-and-ext/eio/tests/eio_stat_error.php on line 31
     string(%d) "eio_%stat"
     int(%d)
     string(%d) "eio_%stat"
--
========DONE========
FAIL Check for eio_*stat functions' error behaviour [tests/eio_stat_error.phpt] 
TEST 29/30 [tests/eio_write_variation.phpt]
========DIFF========
001+ Deprecated: eio_open(): Passing null to parameter #3 ($mode) of type int is deprecated in /work/GIT/pecl-and-ext/eio/tests/eio_write_variation.php on line 17
002+ 
003+ Deprecated: eio_write(): Passing null to parameter #5 ($pri) of type int is deprecated in /work/GIT/pecl-and-ext/eio/tests/eio_write_variation.php on line 16
     array(4) {
       ["written"]=>
       int(20)
--
========DONE========
FAIL Check for eio_write function behaviour with `use' keyword within a nested call [tests/eio_write_variation.phpt] 
TEST 30/30 [tests/fork.phpt]
========DIFF========
001+ Deprecated: eio_open(): Passing null to parameter #3 ($mode) of type int is deprecated in /work/GIT/pecl-and-ext/eio/tests/fork.php on line 38
003+ 
004+ Deprecated: eio_write(): Passing null to parameter #5 ($pri) of type int is deprecated in /work/GIT/pecl-and-ext/eio/tests/fork.php on line 37
     w: 20 l: 20 f: 20 c: 20
========DONE========
FAIL Check for eio fork support using pcntl [tests/fork.phpt] 

```

With

```
=====================================================================
TEST RESULT SUMMARY
---------------------------------------------------------------------
Exts skipped    :    0
Exts tested     :  123
---------------------------------------------------------------------

Number of tests :   30                28
Tests skipped   :    2 (  6.7%) --------
Tests warned    :    0 (  0.0%) (  0.0%)
Tests failed    :    0 (  0.0%) (  0.0%)
Tests passed    :   28 ( 93.3%) (100.0%)
---------------------------------------------------------------------
Time taken      :    1 seconds
=====================================================================

```