### PR TITLE
use zend_ce_exception instead of zend_exception_get_default() for 8.5

### DIFF
--- a/php8/php_eio.c
+++ b/php8/php_eio.c
@@ -813,7 +813,7 @@ static php_socket_t php_eio_zval_to_fd(zval *pfd)
 		/* PHP stream or PHP socket resource  */
 		if ((stream = (php_stream *)zend_fetch_resource2(Z_RES_P(pfd), NULL, php_file_le_stream(), php_file_le_pstream())) != NULL) {
 			if (php_stream_is(stream, PHP_STREAM_IS_MEMORY) || php_stream_is(stream, PHP_STREAM_IS_TEMP)) {
-				zend_throw_exception(zend_exception_get_default(),
+				zend_throw_exception(zend_ce_exception,
 						"Cannot fetch file descriptor from memory based stream", 0);
 				return -1;
 			}
@@ -821,7 +821,7 @@ static php_socket_t php_eio_zval_to_fd(zval *pfd)
 			php_stream_from_zval_no_verify(stream, pfd);
 
 			if (stream == NULL) {
-				zend_throw_exception(zend_exception_get_default(), "Stream resource is invalid", 0);
+				zend_throw_exception(zend_ce_exception, "Stream resource is invalid", 0);
 				return -1;
 			}
 
@@ -867,11 +867,11 @@ static php_socket_t php_eio_zval_to_fd(zval *pfd)
 		/* Numeric fd */
 		file_desc = Z_LVAL_P(pfd);
 		if (file_desc < 0) {
-			zend_throw_exception(zend_exception_get_default(), "Invalid file descriptor", 0);
+			zend_throw_exception(zend_ce_exception, "Invalid file descriptor", 0);
 			return -1;
 		}
 	} else {
-		zend_throw_exception(zend_exception_get_default(), "Invalid file descriptor", 0);
+		zend_throw_exception(zend_ce_exception, "Invalid file descriptor", 0);
 		return -1;
 	}
 


### PR DESCRIPTION
* `zend_ce_exception` available since 7.0
* `zend_exception_get_default` removed in 8.5